### PR TITLE
Binary reader

### DIFF
--- a/test/data/test-binary.vot
+++ b/test/data/test-binary.vot
@@ -1,0 +1,42 @@
+<?xml version='1.0'?>
+<VOTABLE version="1.4"
+ xmlns="http://www.ivoa.net/xml/VOTable/v1.3">
+<!--
+ !  VOTable written by STIL version 4.2-1 (uk.ac.starlink.votable.VOTableWriter)
+ !  at 2024-07-19T14:53:18
+ !-->
+<RESOURCE>
+<TABLE nrows="10">
+<FIELD datatype="short" name="s_byte">
+<VALUES null='-32768'/>
+</FIELD>
+<FIELD datatype="short" name="s_short">
+<VALUES null='-32768'/>
+</FIELD>
+<FIELD datatype="int" name="s_int">
+<VALUES null='-2147483648'/>
+</FIELD>
+<FIELD datatype="long" name="s_long">
+<VALUES null='-9223372036854775808'/>
+</FIELD>
+<FIELD datatype="float" name="s_float"/>
+<FIELD datatype="double" name="s_double"/>
+<FIELD arraysize="*" datatype="char" name="s_string"/>
+<FIELD datatype="boolean" name="s_boolean"/>
+<DATA>
+<BINARY>
+<STREAM encoding='base64'>
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAR6ZXJvRoAAAAEAAAABAAAA
+AAAAAAE/gAAAP/AAAAAAAAAAAAADb25lVAACgAAAAAACAAAAAAAAAAJAAAAAQAAA
+AAAAAAAAAAADdHdvRgADAAOAAAAAAAAAAAAAAANAQAAAQAgAAAAAAAAAAAAFdGhy
+ZWVUAAQABAAAAASAAAAAAAAAAECAAABAEAAAAAAAAAAAAARmb3VyRgAFAAUAAAAF
+AAAAAAAAAAV/wAAAQBQAAAAAAAAAAAAEZml2ZVQABgAGAAAABgAAAAAAAAAGQMAA
+AH/4AAAAAAAAAAAAA3NpeEYABwAHAAAABwAAAAAAAAAHQOAAAEAcAAAAAAAAAAAA
+AFQACAAIAAAACAAAAAAAAAAIQQAAAEAgAAAAAAAAAAAADicgIlwiIicgOyAnJjw+
+IAAJAAkAAAAJAAAAAAAAAAl/wAAAf/gAAAAAAAAAAAAAVA==
+</STREAM>
+</BINARY>
+</DATA>
+</TABLE>
+</RESOURCE>
+</VOTABLE>

--- a/test/data/test-binary2.vot
+++ b/test/data/test-binary2.vot
@@ -1,0 +1,34 @@
+<?xml version='1.0'?>
+<VOTABLE version="1.4"
+ xmlns="http://www.ivoa.net/xml/VOTable/v1.3">
+<!--
+ !  VOTable written by STIL version 4.2-1 (uk.ac.starlink.votable.VOTableWriter)
+ !  at 2024-07-19T14:53:18
+ !-->
+<RESOURCE>
+<TABLE nrows="10">
+<FIELD datatype="short" name="s_byte"/>
+<FIELD datatype="short" name="s_short"/>
+<FIELD datatype="int" name="s_int"/>
+<FIELD datatype="long" name="s_long"/>
+<FIELD datatype="float" name="s_float"/>
+<FIELD datatype="double" name="s_double"/>
+<FIELD arraysize="*" datatype="char" name="s_string"/>
+<FIELD datatype="boolean" name="s_boolean"/>
+<DATA>
+<BINARY2>
+<STREAM encoding='base64'>
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEemVyb0aAAAAAAQAAAAEA
+AAAAAAAAAT+AAAA/8AAAAAAAAAAAAANvbmVUQAACAAAAAAACAAAAAAAAAAJAAAAA
+QAAAAAAAAAAAAAADdHdvRiAAAwADAAAAAAAAAAAAAAADQEAAAEAIAAAAAAAAAAAA
+BXRocmVlVBAABAAEAAAABAAAAAAAAAAAQIAAAEAQAAAAAAAAAAAABGZvdXJGCAAF
+AAUAAAAFAAAAAAAAAAV/wAAAQBQAAAAAAAAAAAAEZml2ZVQEAAYABgAAAAYAAAAA
+AAAABkDAAAB/+AAAAAAAAAAAAANzaXhGAgAHAAcAAAAHAAAAAAAAAAdA4AAAQBwA
+AAAAAAAAAAAAVAEACAAIAAAACAAAAAAAAAAIQQAAAEAgAAAAAAAAAAAADicgIlwi
+IicgOyAnJjw+IAAACQAJAAAACQAAAAAAAAAJf8AAAH/4AAAAAAAAAAAAAFQ=
+</STREAM>
+</BINARY2>
+</DATA>
+</TABLE>
+</RESOURCE>
+</VOTABLE>

--- a/test/data/test-tabledata.vot
+++ b/test/data/test-tabledata.vot
@@ -1,0 +1,124 @@
+<?xml version='1.0'?>
+<VOTABLE version="1.4"
+ xmlns="http://www.ivoa.net/xml/VOTable/v1.3">
+<!--
+ !  VOTable written by STIL version 4.2-1 (uk.ac.starlink.votable.VOTableWriter)
+ !  at 2024-07-19T14:53:18
+ !-->
+<RESOURCE>
+<TABLE nrows="10">
+<FIELD datatype="short" name="s_byte"/>
+<FIELD datatype="short" name="s_short"/>
+<FIELD datatype="int" name="s_int"/>
+<FIELD datatype="long" name="s_long"/>
+<FIELD datatype="float" name="s_float"/>
+<FIELD datatype="double" name="s_double"/>
+<FIELD arraysize="*" datatype="char" name="s_string"/>
+<FIELD datatype="boolean" name="s_boolean"/>
+<DATA>
+<TABLEDATA>
+  <TR>
+    <TD>0</TD>
+    <TD>0</TD>
+    <TD>0</TD>
+    <TD>0</TD>
+    <TD>0.0</TD>
+    <TD>0.0</TD>
+    <TD>zero</TD>
+    <TD>F</TD>
+  </TR>
+  <TR>
+    <TD></TD>
+    <TD>1</TD>
+    <TD>1</TD>
+    <TD>1</TD>
+    <TD>1.0</TD>
+    <TD>1.0</TD>
+    <TD>one</TD>
+    <TD>T</TD>
+  </TR>
+  <TR>
+    <TD>2</TD>
+    <TD></TD>
+    <TD>2</TD>
+    <TD>2</TD>
+    <TD>2.0</TD>
+    <TD>2.0</TD>
+    <TD>two</TD>
+    <TD>F</TD>
+  </TR>
+  <TR>
+    <TD>3</TD>
+    <TD>3</TD>
+    <TD></TD>
+    <TD>3</TD>
+    <TD>3.0</TD>
+    <TD>3.0</TD>
+    <TD>three</TD>
+    <TD>T</TD>
+  </TR>
+  <TR>
+    <TD>4</TD>
+    <TD>4</TD>
+    <TD>4</TD>
+    <TD></TD>
+    <TD>4.0</TD>
+    <TD>4.0</TD>
+    <TD>four</TD>
+    <TD>F</TD>
+  </TR>
+  <TR>
+    <TD>5</TD>
+    <TD>5</TD>
+    <TD>5</TD>
+    <TD>5</TD>
+    <TD></TD>
+    <TD>5.0</TD>
+    <TD>five</TD>
+    <TD>T</TD>
+  </TR>
+  <TR>
+    <TD>6</TD>
+    <TD>6</TD>
+    <TD>6</TD>
+    <TD>6</TD>
+    <TD>6.0</TD>
+    <TD></TD>
+    <TD>six</TD>
+    <TD>F</TD>
+  </TR>
+  <TR>
+    <TD>7</TD>
+    <TD>7</TD>
+    <TD>7</TD>
+    <TD>7</TD>
+    <TD>7.0</TD>
+    <TD>7.0</TD>
+    <TD></TD>
+    <TD>T</TD>
+  </TR>
+  <TR>
+    <TD>8</TD>
+    <TD>8</TD>
+    <TD>8</TD>
+    <TD>8</TD>
+    <TD>8.0</TD>
+    <TD>8.0</TD>
+    <TD>' "\""' ; '&amp;&lt;&gt;</TD>
+    <TD></TD>
+  </TR>
+  <TR>
+    <TD>9</TD>
+    <TD>9</TD>
+    <TD>9</TD>
+    <TD>9</TD>
+    <TD>NaN</TD>
+    <TD>NaN</TD>
+    <TD></TD>
+    <TD>T</TD>
+  </TR>
+</TABLEDATA>
+</DATA>
+</TABLE>
+</RESOURCE>
+</VOTABLE>

--- a/test/data/testdata.sh
+++ b/test/data/testdata.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Creates some test tables using STILTS.
+# See http://www.starlink.ac.uk/stilts/
+
+nrow=10
+coltypes=s
+
+test -r stilts.jar || curl -OL http://www.starlink.ac.uk/stilts/stilts.jar
+for fmt in tabledata binary2 binary
+do
+   file=test-${fmt}.vot
+   echo "Writing $file"
+   Fmt=`echo $fmt | tr a-z A-Z`
+   java -jar stilts.jar tpipe in=:test:${nrow},${coltypes} \
+                              ofmt="votable(format=$Fmt)" out=$file
+done

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,6 +203,22 @@ end
     @test length(tbl) == 5
 end
 
+@testitem "read formats" begin
+    include("testutil.jl")
+    formats = ["tabledata", "binary2", "binary"]
+    # These files are written (using STILTS) by a script in the data directory.
+    # They have different serializations but, as far as possible,
+    # identical content.
+    files = map(fmt -> joinpath(@__DIR__, "data/test-$fmt.vot"), formats)
+    tables = VOTables.read.(files)
+    @test length(tables) == 3
+    t1 = tables[1]
+    @test length(Tables.columns(t1)) == 8
+    @test length(Tables.rows(t1)) == 10
+    @test isapproxtable(t1, tables[2])
+    @test isapproxtable(t1, tables[3])
+end
+
 @testitem "write" begin
     using StructArrays.Tables
     using DictArrays, StructArrays

--- a/test/testutil.jl
+++ b/test/testutil.jl
@@ -1,0 +1,29 @@
+using StructArrays.Tables
+
+isblank(d)::Bool = ismissing(d) || isnothing(d) || length(d) == 0 || (d isa Number && isnan(d))
+
+squashblank(d) = if isblank(d) missing else d end
+
+function isapproxtable(t1, t2)
+    cols1 = Tables.columns(t1)
+    cols2 = Tables.columns(t2)
+    if length(cols1) != length(cols2)
+        @error "column length mismatch $(length(cols1)) != $(length(cols2))"
+        return false
+    end
+    for (icol, (c1, c2)) in enumerate(zip(cols1, cols2))
+        cs1 = squashblank.(c1)
+        cs2 = squashblank.(c2)
+        if !isequal(cs1, cs2)
+            cname = Tables.schema(t1).names[icol]
+            @error """
+                data mismatch for column $icol $cname:
+                --> t1 $cname: $cs1
+                --> t2 $cname: $cs2
+            """
+            return false
+        end
+    end
+    true
+end
+


### PR DESCRIPTION
Adds support for the BINARY VOTable serialization variant, along with some tests that check the three serialization formats are consistent.  There are test failures if this is applied against the master branch at time of submission; PRs #2 and #3 should be applied to make this go away.