### PR TITLE
Handle empty column unit string

### DIFF
--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -37,6 +37,11 @@ function unit_vot_to_jl(col, vot_unit::AbstractString)
                 r"\barcmin\b" => "arcminute",
                 r"\bum\b" => "μm",
                 r"\bAngstrom\b" => "angstrom")
+            
+            # Handle empty vot_unit string
+            if isempty(__)
+                __ == "NoUnits"
+            end
             uparse(unit_context=[Unitful; Unitful.unitmodules], __)
         end
     catch exception

--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -40,9 +40,10 @@ function unit_vot_to_jl(col, vot_unit::AbstractString)
             
             # Handle empty vot_unit string
             if isempty(__)
-                __ == "NoUnits"
+                NoUnits
+            else
+                uparse(unit_context=[Unitful; Unitful.unitmodules], __)
             end
-            uparse(unit_context=[Unitful; Unitful.unitmodules], __)
         end
     catch exception
         if exception isa ArgumentError && occursin("could not be found in unit modules", exception.msg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ using TestItemRunner
     @test unit_vot_to_jl([1.0], "[W/um]") |> only === 10.0u"W*μm^-1"
     @test unit_vot_to_jl([1.0], "angstrom") |> only === 1.0u"Å"
     @test unit_vot_to_jl([1.0], "Angstrom") |> only === 1.0u"Å"
+    @test unit_vot_to_jl([1.0], "") |> only === 1.0
 end
 
 @testitem "read 1" begin


### PR DESCRIPTION
Following #10, which fixed the wavelength parsing for SVO filter tables, I am still getting a warning that I found was associated with the transmission (or throughput) column having no unit, which is represented by a blank string. Currently this causes a warning to be thrown in VOTables, when I think it is normal for some columns to have no unit and so an empty string should be a valid input. This PR adds a check to determine if the `vot_unit` string is empty and, if so, returns `Unitful.NoUnits`. A test has been added to validate this behavior. With this PR, SVO filter tables can be read successfully with no errors or warnings.