### PR TITLE
bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VOTables"
 uuid = "3abbdab7-df67-4801-8590-8effec53f469"
 authors = ["Alexander Plavin <alexander@plav.in>"]
-version = "0.1.21"
+version = "0.1.22"
 
 [deps]
 AccessorsExtra = "33016aad-b69d-45be-9359-82a41f556fd4"


### PR DESCRIPTION
With 000000001e95999a4824c30857e98cf64bf38ecb, VOTables now seems to install properly on Windows platforms. Can you tag and release a new version?