### PR TITLE
Handle empty unit strings

### DIFF
--- a/src/VOTables.jl
+++ b/src/VOTables.jl
@@ -188,6 +188,12 @@ end
 function postprocess_col(col, attrs; unitful::Bool, timeorigin::Real=0)
     ucds = split(get(attrs, :ucd, ""), ";")
     unit = get(attrs, :unit, nothing)
+    # An empty unit attribute (unit="") is semantically equivalent to no unit.
+    # Some services emit unit="" on non-numeric columns rather than omitting the
+    # attribute entirely. Without this normalization, the empty string bypasses
+    # the `isnothing(unit)` guards below and causes spurious warnings for every
+    # string column that carries unit="" (common in SVO and other VO services).
+    unit == "" && (unit = nothing)
     if "time.epoch" in ucds
         if nonmissingtype(eltype(col)) <: AbstractString && unit == "'Y:M:D'"
             map(x -> ismissing(x) ? missing : parse(Date, x, dateformat"Y-m-d"), col)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -283,6 +283,31 @@ end
     @test_logs VOTables.read(votfile; unitful=true, quiet=true, strict=false)
 end
 
+@testitem "empty unit string" begin
+    # unit="" is semantically "no unit" and should not warn on non-numeric columns.
+    # Regression test for SVO Filter Profile Service, which emits unit="" on every
+    # FIELD element including string columns like filterID and PhotSystem.
+    xml = """
+    <?xml version="1.0"?>
+    <VOTABLE version="1.1">
+      <RESOURCE type="results">
+        <TABLE>
+          <FIELD name="filterID" datatype="char" arraysize="*" unit=""/>
+          <DATA>
+            <TABLEDATA>
+              <TR><TD>SLOAN/SDSS.g</TD></TR>
+              <TR><TD>SLOAN/SDSS.r</TD></TR>
+            </TABLEDATA>
+          </DATA>
+        </TABLE>
+      </RESOURCE>
+    </VOTABLE>"""
+
+    # Should parse without warnings from non-numeric column with unit=""
+    tbl = @test_logs VOTables.read(IOBuffer(xml); unitful=true)
+    @test tbl.filterID == ["SLOAN/SDSS.g", "SLOAN/SDSS.r"]
+end
+
 @testitem "read error" begin
     using Dates
     using Unitful, UnitfulAstro, UnitfulAngles


### PR DESCRIPTION
The VO-compliant SVO Filter Profile Service emits `unit=""` on every `FIELD` element, including purely textual columns like `filterID`, `PhotSystem`, and `DetectorType`. VOTables.jl stores the empty string verbatim in `attrs`, so the `isnothing(unit)` guards in `postprocess_col` don't fire. The result is one `@warn` per string column:

```julia
using VOTables, HTTP

url = "https://svo2.cab.inta-csic.es/svo/theory/fps3/fps.php"
resp = HTTP.get(url; query=Dict("Facility" => "SLOAN", "WavelengthEff" => "1000/5000"))
VOTables.read(IOBuffer(resp.body))
```

Before this PR, that produces 17 warnings (one per string column):

```
┌ Warning: column with a non-numeric eltype has a unit specified; ignoring the unit
│   column = "FilterProfileService"
│   unit = ""
│   eltype(col) = String
│   first(col) = "ivo://svo/fps"
└ @ VOTables ~/.julia/packages/VOTables/L37bJ/src/VOTables.jl:218
┌ Warning: column with a non-numeric eltype has a unit specified; ignoring the unit
│   column = "filterID"
│   unit = ""
│   eltype(col) = String
│   first(col) = "SLOAN/SDSS.uprime_filter"
└ @ VOTables ~/.julia/packages/VOTables/L37bJ/src/VOTables.jl:218
┌ Warning: column with a non-numeric eltype has a unit specified; ignoring the unit
│   column = "WavelengthUnit"
│   unit = ""
│   eltype(col) = String
│   first(col) = "Angstrom"
```

The upstream XML looks like:

```xml
<FIELD name="FilterProfileService" ucd="meta.ref.ivorn" unit="" datatype="char" arraysize="*"/>
<FIELD name="filterID"           ucd="meta.ref.ivoid" unit="" datatype="char" arraysize="*"/>
<FIELD name="WavelengthRef"      ucd="em.wl;meta.main" unit="Angstrom" datatype="double" />
```

Numeric columns carry meaningful units (`Angstrom`, `Jy`, `erg/cm2/s/A`); string columns carry `unit=""`. Omitting the attribute entirely is valid, but services are free to include it with an empty value which semantically means the attribute has no unit.

**The fix:** one line in `postprocess_col` that normalizes `unit=""` to `nothing` before any of the branching logic. This is the narrowest possible change and it only affects the semantic question "does this column have a meaningful unit?" All existing `isnothing(unit)` checks then handle it correctly.